### PR TITLE
Build with AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+build_script:
+- cmd: >-
+    C:\msys64\usr\bin\bash -lc "pacman -S --needed --noconfirm mingw-w64-i686-premake mingw-w64-x86_64-premake"
+
+    set MSYSTEM=MINGW32
+
+    C:\msys64\usr\bin\bash -lc "cd '%cd%' && premake4 gmake && make && make config=release"
+
+    git clean -xfd
+
+    set MSYSTEM=MINGW64
+
+    C:\msys64\usr\bin\bash -lc "cd '%cd%' && premake4 gmake && make && make config=release"


### PR DESCRIPTION
This adds a configuration file for AppVeyor which will automatically build ticpp in 32 bit / 64 bit and debug / release.

The only thing needed is to activate it on AppVeyor, output will look similar to this: https://ci.appveyor.com/project/jhasse/ticpp